### PR TITLE
feat(access-control): Support `i18n` infrastructure

### DIFF
--- a/project/access-control/src/main/java/com/serinity/accesscontrol/App.java
+++ b/project/access-control/src/main/java/com/serinity/accesscontrol/App.java
@@ -1,28 +1,48 @@
+/**
+ * App.java
+ *
+ * Serinity app entry point
+ *
+ * <p>none</p>
+ *
+ * @author @ZouariOmar (zouariomar20@gmail.com)
+ * @version 1.0
+ * @since 2026-01-28
+ *
+ * <a href="https://github.com/zouari-oss/hashhash-books" target="_blank">App.java</a>
+ */
+
+// `App` package name
 package com.serinity.accesscontrol;
 
+// `serinity` imports
+import com.serinity.accesscontrol.flag.FXMLFile;
+import com.serinity.accesscontrol.util.FXMLLoaderUtil;
+import com.serinity.accesscontrol.util.I18nUtil;
+
+// `javafx` imports
 import javafx.application.Application;
-import javafx.scene.Scene;
-import javafx.scene.control.Label;
-import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 /**
- * JavaFX App
+ * App class entry point (launcher)
+ *
+ * <p>
+ * More detailed description or notes.
+ * </p>
  */
 public class App extends Application {
-
-  @Override
-  public void start(Stage stage) {
-    var javaVersion = SystemInfo.javaVersion();
-    var javafxVersion = SystemInfo.javafxVersion();
-
-    var label = new Label("Hello, JavaFX " + javafxVersion + ", running on Java " + javaVersion + ".");
-    var scene = new Scene(new StackPane(label), 640, 480);
-    stage.setScene(scene);
-    stage.show();
+  public static void main(final String[] args) {
+    launch();
   }
 
-  public static void main(String[] args) {
-    launch();
+  @Override
+  public void start(final Stage stage) {
+    I18nUtil.applySupportedLocale();
+    stage.setScene(FXMLLoaderUtil.loadScene(
+        this.getClass(),
+        FXMLFile.SIGNIN.getFileName(),
+        I18nUtil.getBundle()));
+    stage.show();
   }
 } // App class

--- a/project/access-control/src/main/java/com/serinity/accesscontrol/flag/FXMLFile.java
+++ b/project/access-control/src/main/java/com/serinity/accesscontrol/flag/FXMLFile.java
@@ -1,0 +1,43 @@
+/**
+ * FXMLFile.java
+ *
+ * Fxml filename manager (enum)
+ *
+ * <p>none</p>
+ *
+ * @author @ZouariOmar (zouariomar20@gmail.com)
+ * @version 1.0
+ * @since 2026-01-28
+ *
+ * <a href="https://github.com/zouari-oss/serinity" target="_blank">FXMLFile.java</a>
+ */
+
+// `FXMLFile` package name
+package com.serinity.accesscontrol.flag;
+
+/**
+ * Fxml file manager (enum)
+ *
+ * <p>
+ * Contain all the access-control package fxml filenames
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * // Example
+ * final static String SIGININ_FILENAME = FXMLFile.SIGNIN.getFileName();
+ * }</pre>
+ */
+public enum FXMLFile {
+  SIGNIN("/fxml/sign-in.fxml");
+
+  private final String fileName;
+
+  private FXMLFile(final String fileName) {
+    this.fileName = fileName;
+  }
+
+  public final String getFileName() {
+    return fileName;
+  }
+} // FXMLFile enum

--- a/project/access-control/src/main/java/com/serinity/accesscontrol/flag/MessageKey.java
+++ b/project/access-control/src/main/java/com/serinity/accesscontrol/flag/MessageKey.java
@@ -1,0 +1,20 @@
+
+// `MessageKey` package name
+package com.serinity.accesscontrol.flag;
+
+public enum MessageKey {
+  GREETING("greeting"),
+  LOGIN("login"),
+  EXIT("exit"),
+  LANGUAGES("languages");
+
+  private final String value;
+
+  MessageKey(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+} // MessageKey enum

--- a/project/access-control/src/main/java/com/serinity/accesscontrol/flag/PropertyBundle.java
+++ b/project/access-control/src/main/java/com/serinity/accesscontrol/flag/PropertyBundle.java
@@ -1,0 +1,18 @@
+package com.serinity.accesscontrol.flag;
+
+public enum PropertyBundle {
+  SUPPORTED_LANGUAGES_BUNDLE("bundles.supported-languages"),
+  DEFAULT_MESSAGES_BUNDLE("bundles.messages"),
+  ENGLISH_MESSAGES_BUNDLE("bundles.messages"),
+  FRENCH_MESSAGES_BUNDLE("bundles.messages_fr");
+
+  private final String baseName;
+
+  PropertyBundle(final String baseName) {
+    this.baseName = baseName;
+  }
+
+  public final String getBaseName() {
+    return baseName;
+  }
+} // PropertyBundle enum

--- a/project/access-control/src/main/java/com/serinity/accesscontrol/flag/SupportedLanguage.java
+++ b/project/access-control/src/main/java/com/serinity/accesscontrol/flag/SupportedLanguage.java
@@ -1,0 +1,19 @@
+package com.serinity.accesscontrol.flag;
+
+import java.util.Locale;
+
+public enum SupportedLanguage {
+  DEFAULT(Locale.ENGLISH),
+  EN(Locale.ENGLISH),
+  FR(Locale.FRENCH);
+
+  private final Locale locale;
+
+  SupportedLanguage(Locale locale) {
+    this.locale = locale;
+  }
+
+  public Locale getLocale() {
+    return locale;
+  }
+}

--- a/project/access-control/src/main/java/com/serinity/accesscontrol/util/FXMLLoaderUtil.java
+++ b/project/access-control/src/main/java/com/serinity/accesscontrol/util/FXMLLoaderUtil.java
@@ -1,0 +1,65 @@
+/**
+ * FXMLLoaderUtil.java
+ *
+ * Fxml loader util class
+ *
+ * <p>none</p>
+ *
+ * @author @ZouariOmar (zouariomar20@gmail.com)
+ * @version 1.0
+ * @since 2026-01-28
+ *
+ * <a href="https://github.com/zouari-oss/serinity" target="_blank">FXMLLoaderUtil.java</a>
+ */
+
+// `FXMLLoaderUtil` package name
+package com.serinity.accesscontrol.util;
+
+// `java` imports
+import java.io.IOException;
+import java.net.URL;
+import java.util.ResourceBundle;
+
+// `javafx` imports
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+
+/**
+ * Fxml loader util class
+ *
+ * <p>
+ * none
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * // Example
+ * FXMLLoaderUtil.loadScene(this.getClass(), FXMLFile.SIGNIN.getFileName())
+ * }
+ * </pre>
+ */
+final public class FXMLLoaderUtil {
+  // No i18n
+  public static Scene loadScene(final Class<?> caller, final String fxmlPath) {
+    return loadScene(caller, fxmlPath, null);
+  }
+
+  public static Scene loadScene(final Class<?> caller, final String fxmlPath, final ResourceBundle bundle) {
+    try {
+      final URL fxmlUrl = caller.getResource(fxmlPath);
+      if (fxmlUrl == null) {
+        throw new IllegalStateException("[ERROR] FXML file not found: " + fxmlPath);
+      }
+
+      final FXMLLoader loader = new FXMLLoader(fxmlUrl);
+      if (bundle != null) {
+        loader.setResources(bundle);
+      }
+
+      return new Scene(loader.load());
+
+    } catch (final IOException e) {
+      throw new RuntimeException("[ERROR] Failed to load FXML: " + fxmlPath, e);
+    }
+  }
+} // FXMLLoaderUtil class

--- a/project/access-control/src/main/java/com/serinity/accesscontrol/util/I18nUtil.java
+++ b/project/access-control/src/main/java/com/serinity/accesscontrol/util/I18nUtil.java
@@ -1,0 +1,74 @@
+/**
+ * ClassName.java
+ *
+ * Short description of this class or file.
+ *
+ * <p>Detailed explanation of the class, its responsibilities, and usage.</p>
+ *
+ * @author @ZouariOmar (zouariomar20@gmail.com)
+ * @version 1.0
+ * @since 2026-01-29
+ *
+ * <a href="https://simplelocalize.io/blog/posts/java-internationalization" target="_blank">Java 24: Internationalization</a>
+ */
+
+// `I18nUtil` package name
+package com.serinity.accesscontrol.util;
+
+// `java` imports
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+
+// `serinity` imports
+import com.serinity.accesscontrol.flag.MessageKey;
+import com.serinity.accesscontrol.flag.PropertyBundle;
+import com.serinity.accesscontrol.flag.SupportedLanguage;
+
+public final class I18nUtil {
+  private static Locale currentLocale = Locale.getDefault();
+
+  private static ResourceBundle bundle = ResourceBundle.getBundle(
+      PropertyBundle.DEFAULT_MESSAGES_BUNDLE.getBaseName(),
+      currentLocale);
+
+  private I18nUtil() {
+  }
+
+  public static String get(String key) {
+    return bundle.getString(key);
+  }
+
+  public static void setLocale(Locale locale) {
+    currentLocale = locale;
+
+    bundle = ResourceBundle.getBundle(
+        PropertyBundle.DEFAULT_MESSAGES_BUNDLE.getBaseName(),
+        currentLocale);
+  }
+
+  public static Locale getLocale() {
+    return currentLocale;
+  }
+
+  public static ResourceBundle getBundle() {
+    return bundle;
+  }
+
+  public static List<Locale> getSupportedLanguages() {
+    ResourceBundle config = ResourceBundle.getBundle(PropertyBundle.SUPPORTED_LANGUAGES_BUNDLE.getBaseName());
+
+    return List.of(config.getString(MessageKey.LANGUAGES.getValue()).split(","))
+        .stream()
+        .map(String::trim)
+        .map(Locale::forLanguageTag)
+        .collect(Collectors.toList());
+  }
+
+  public static void applySupportedLocale() {
+    if (!getSupportedLanguages().contains(currentLocale)) {
+      setLocale(SupportedLanguage.DEFAULT.getLocale());
+    }
+  }
+} // I18nUtil class

--- a/project/access-control/src/main/java/module-info.java
+++ b/project/access-control/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 module com.serinity {
   requires transitive javafx.controls;
+  requires javafx.fxml;
 
   exports com.serinity.accesscontrol;
 }

--- a/project/access-control/src/main/resources/i18n/messages.properties
+++ b/project/access-control/src/main/resources/i18n/messages.properties
@@ -1,0 +1,3 @@
+greeting=Hello
+login=Login
+exit=Exit

--- a/project/access-control/src/main/resources/i18n/messages_fr.properties
+++ b/project/access-control/src/main/resources/i18n/messages_fr.properties
@@ -1,0 +1,3 @@
+greeting=Bonjour
+login=Connexion
+exit=Quitter

--- a/project/access-control/src/main/resources/i18n/supported-languages.properties
+++ b/project/access-control/src/main/resources/i18n/supported-languages.properties
@@ -1,0 +1,1 @@
+languages=en,fr


### PR DESCRIPTION
This pull request introduces internationalization (i18n) support and refactors the JavaFX application entry point for the Serinity access control project. The changes enable language selection, resource bundle management, and FXML file handling, laying the groundwork for a localized user interface.

**Internationalization (i18n) support:**

* Added the `I18nUtil` utility class to manage locales, resource bundles, and supported languages, including automatic fallback to a default language if the current locale is unsupported.
* Introduced enums `PropertyBundle`, `MessageKey`, and `SupportedLanguage` to centralize and standardize access to resource bundle names, message keys, and supported locales. [[1]](diffhunk://#diff-cc892026972f6282e54dc58c72892a9cbe6351c0e779983c170a0176b5601b92R1-R18) [[2]](diffhunk://#diff-9bc96cd0d1a0d15152d8a5994573eae4af2cd32d8fe67f0563321270c359d4c2R1-R20) [[3]](diffhunk://#diff-5ac2bfa9050b5438981af5b5125cb29436bb2c2ffff9671d890bf83d68201598R1-R19)
* Added resource bundles for English and French (`messages.properties`, `messages_fr.properties`) and a configuration file for supported languages (`supported-languages.properties`). [[1]](diffhunk://#diff-c8bffda6e29e41e7b65250d0e2682e724570a39d5721edc430e423ee0e85392cR1-R3) [[2]](diffhunk://#diff-ade69d4147e0ae879f541d01b6fa826de62368db1ae33944f4aaae4e0d2d78e7R1-R3) [[3]](diffhunk://#diff-cc37c4bc427435ca1cf7d3c5c9e2ec267a1709df91d67a98d809ff46fa3bd4d7R1)

**FXML and JavaFX application refactoring:**

* Refactored the `App` class to load the sign-in FXML view using the new `FXMLLoaderUtil`, and to apply the appropriate locale at startup.
* Added the `FXMLFile` enum to manage FXML file paths in a type-safe way.
* Introduced the `FXMLLoaderUtil` class to simplify loading FXML files with optional resource bundles.

**Module and dependency updates:**

* Updated `module-info.java` to require `javafx.fxml` for FXML support.
---
[DETAILS - @ZouariOmar ]
- We support `fr` & `en`
- We make the work more dynamique, so any refactoring action will be easy :)