### PR TITLE
feat(mood-control): modularize CSS styles

### DIFF
--- a/project/mood-control/src/main/java/com/serinity/moodcontrol/controller/StateOfMindWizardController.java
+++ b/project/mood-control/src/main/java/com/serinity/moodcontrol/controller/StateOfMindWizardController.java
@@ -309,4 +309,4 @@ public class StateOfMindWizardController {
       current.setTranslateX(0);
     });
   }
-} // StateOfMindWizardController class
+}

--- a/project/mood-control/src/main/java/com/serinity/moodcontrol/dao/MoodEntryDao.java
+++ b/project/mood-control/src/main/java/com/serinity/moodcontrol/dao/MoodEntryDao.java
@@ -8,7 +8,7 @@ import java.util.*;
 
 public class MoodEntryDao {
 
-  // ---------------- SAVE ----------------
+  // SAVE
   public long save(final MoodEntry entry) throws SQLException {
     try (Connection cn = DbConnection.getConnection()) {
       cn.setAutoCommit(false);
@@ -37,7 +37,7 @@ public class MoodEntryDao {
     }
   }
 
-  // ---------------- READ HISTORY ----------------
+  // HISTORY
   public List<MoodHistoryItem> findHistory(final long userId, final Integer lastDays, final String typeFilter)
       throws SQLException {
 
@@ -53,9 +53,9 @@ public class MoodEntryDao {
       params.add(Integer.valueOf(lastDays));
     }
 
-    // IMPORTANT:
-    // typeFilter should be "ALL" or null or "MOMENT" or "DAY" (codes), not UI
-    // strings
+
+    // typeFilter  "MOMENT" or "DAY" codes strings
+
     if (typeFilter != null && !"ALL".equalsIgnoreCase(typeFilter)) {
       final String dbType = typeFilter.trim().toUpperCase(Locale.ROOT);
       if ("MOMENT".equals(dbType) || "DAY".equals(dbType)) {

--- a/project/mood-control/src/main/java/com/serinity/moodcontrol/model/MoodEntry.java
+++ b/project/mood-control/src/main/java/com/serinity/moodcontrol/model/MoodEntry.java
@@ -4,78 +4,78 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MoodEntry {
-  private long id; // db generated
-  private long userId = 1; // TEMP  User id
+    private long id; // db generated
+    private long userId = 1; // TEMP  User id
 
-  private String momentType;
-  private int moodLevel;
+    private String momentType;
+    private int moodLevel;
 
-  private List<String> emotions = new ArrayList<>(),
-      influences = new ArrayList<>();
+    private List<String> emotions = new ArrayList<>(),
+            influences = new ArrayList<>();
 
-  public MoodEntry() {
-  }
+    public MoodEntry() {
+    }
 
-  public MoodEntry(
-      final long userId,
-      final String momentType,
-      final int moodLevel,
-      final List<String> emotions,
-      final List<String> influences) {
-    this.userId = userId;
-    this.momentType = momentType;
-    this.moodLevel = moodLevel;
-    if (emotions != null)
-      this.emotions = emotions;
-    if (influences != null)
-      this.influences = influences;
-  }
+    public MoodEntry(
+            final long userId,
+            final String momentType,
+            final int moodLevel,
+            final List<String> emotions,
+            final List<String> influences) {
+        this.userId = userId;
+        this.momentType = momentType;
+        this.moodLevel = moodLevel;
+        if (emotions != null)
+            this.emotions = emotions;
+        if (influences != null)
+            this.influences = influences;
+    }
 
-  public long getId() {
-    return id;
-  }
+    public long getId() {
+        return id;
+    }
 
-  public void setId(final long id) {
-    this.id = id;
-  }
+    public void setId(final long id) {
+        this.id = id;
+    }
 
-  public long getUserId() {
-    return userId;
-  }
+    public long getUserId() {
+        return userId;
+    }
 
-  public void setUserId(final long userId) {
-    this.userId = userId;
-  }
+    public void setUserId(final long userId) {
+        this.userId = userId;
+    }
 
-  public String getMomentType() {
-    return momentType;
-  }
+    public String getMomentType() {
+        return momentType;
+    }
 
-  public void setMomentType(final String momentType) {
-    this.momentType = momentType;
-  }
+    public void setMomentType(final String momentType) {
+        this.momentType = momentType;
+    }
 
-  public int getMoodLevel() {
-    return moodLevel;
-  }
+    public int getMoodLevel() {
+        return moodLevel;
+    }
 
-  public void setMoodLevel(final int moodLevel) {
-    this.moodLevel = moodLevel;
-  }
+    public void setMoodLevel(final int moodLevel) {
+        this.moodLevel = moodLevel;
+    }
 
-  public List<String> getEmotions() {
-    return emotions;
-  }
+    public List<String> getEmotions() {
+        return emotions;
+    }
 
-  public void setEmotions(final List<String> emotions) {
-    this.emotions = emotions;
-  }
+    public void setEmotions(final List<String> emotions) {
+        this.emotions = emotions;
+    }
 
-  public List<String> getInfluences() {
-    return influences;
-  }
+    public List<String> getInfluences() {
+        return influences;
+    }
 
-  public void setInfluences(final List<String> influences) {
-    this.influences = influences;
-  }
+    public void setInfluences(final List<String> influences) {
+        this.influences = influences;
+    }
 }

--- a/project/mood-control/src/main/resources/styles/journal.css
+++ b/project/mood-control/src/main/resources/styles/journal.css
@@ -1,0 +1,118 @@
+
+
+/* ===== Journal editor  ===== */
+.journal-card {
+    -fx-background-color: white;
+    -fx-background-radius: 14;
+    -fx-border-radius: 14;
+    -fx-padding: 14;
+    -fx-spacing: 6;
+    -fx-border-width: 0 0 0 4;
+    -fx-border-color: transparent transparent transparent rgba(47,127,122,0.35);
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.06), 18, 0.12, 0, 2);
+}
+
+.journal-card:hover {
+    -fx-background-color: #F4FBFA;
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.09), 22, 0.14, 0, 3);
+}
+
+.journal-card-title {
+    -fx-font-size: 15px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #1F5E5A;
+}
+
+.journal-card-meta {
+    -fx-font-size: 12px;
+    -fx-text-fill: rgba(47,127,122,0.65);
+}
+
+.journal-card-preview {
+    -fx-font-size: 13.5px;
+    -fx-text-fill: rgba(0,0,0,0.78);
+    -fx-wrap-text: true;
+    -fx-font-style: italic;
+}
+
+/* Scoped icon  */
+.journal-card .icon-btn {
+    -fx-background-color: rgba(31, 41, 51, 0.06);
+    -fx-text-fill: rgba(0,0,0,0.45);
+}
+
+.journal-card .icon-btn-delete {
+    -fx-text-fill: #B12B28;
+    -fx-background-color: rgba(217, 83, 79, 0.10);
+}
+
+.journal-card .icon-btn:hover {
+    -fx-background-color: rgba(47,127,122,0.12);
+    -fx-text-fill: #2F7F7A;
+}
+
+.journal-card .icon-btn-delete:hover {
+    -fx-background-color: rgba(217, 83, 79, 0.22);
+    -fx-text-fill: #7A1E1B;
+}
+
+.editor-panel {
+    -fx-background-color: #F2FAF9;
+    -fx-background-radius: 18;
+    -fx-border-radius: 18;
+    -fx-border-color: rgba(47,127,122,0.18);
+    -fx-border-width: 1;
+    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.14), 26, 0.16, -7, 0);
+}
+
+.editor-title {
+    -fx-font-size: 18px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #1F5E5A;
+}
+
+.editor-subtitle {
+    -fx-font-size: 12.5px;
+    -fx-text-fill: rgba(31,94,90,0.65);
+}
+
+.prompt-block {
+    -fx-padding: 12 0 6 12;
+    -fx-border-color: transparent transparent transparent rgba(47,127,122,0.35);
+    -fx-border-width: 0 0 0 3;
+}
+
+.prompt-q {
+    -fx-font-size: 13.5px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #2F7F7A;
+}
+
+.prompt-hint {
+    -fx-font-size: 12px;
+    -fx-text-fill: rgba(47,127,122,0.55);
+}
+
+.prompt-answer {
+    -fx-background-radius: 14;
+    -fx-border-radius: 5;
+    -fx-padding: 5;
+    -fx-border-color: rgba(47,127,122,0.18);
+    -fx-background-color: #FFFFFF;
+}
+
+.prompt-answer:focused {
+    -fx-border-color: #2F7F7A;
+    -fx-effect: dropshadow(gaussian, rgba(47,127,122,0.25), 12, 0.3, 0, 0);
+}
+
+.overlay-dim {
+    -fx-background-color: rgba(31,94,90,0.25);
+}
+
+.save-hint {
+    -fx-font-size: 12px;
+    -fx-text-fill: rgba(31,94,90,0.65);
+    -fx-padding: 0 2 0 0;
+    -fx-alignment: CENTER_RIGHT;
+}

--- a/project/mood-control/src/main/resources/styles/mood-home.css
+++ b/project/mood-control/src/main/resources/styles/mood-home.css
@@ -1,0 +1,130 @@
+
+
+/* =========================
+   PAGE HEADER
+   ========================= */
+.page-title {
+    -fx-text-fill: -ser-text;
+    -fx-font-size: 16px;
+    -fx-font-weight: 800;
+}
+
+.page-hint {
+    -fx-background-color: rgba(47, 111, 109, 0.20);
+    -fx-background-radius: 16;
+    -fx-padding: 10 22;
+    -fx-font-size: 14px;
+    -fx-font-weight: 900;
+    -fx-text-fill: #1F2933;
+}
+
+/* =========================
+   MOOD HOME
+   ========================= */
+.mood-hub-row {
+    -fx-background-color: transparent;
+}
+
+.mood-host {
+    -fx-background-color: transparent;
+}
+
+.mood-card-grid {
+    -fx-background-color: transparent;
+}
+
+.mood-card {
+    -fx-alignment: center;
+    -fx-background-color: rgba(255, 255, 255, 0.92);
+    -fx-background-radius: 18;
+    -fx-border-radius: 18;
+    -fx-border-color: rgba(31, 41, 51, 0.08);
+    -fx-border-width: 1;
+
+    -fx-padding: 22;
+    -fx-cursor: hand;
+
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.10), 20, 0.18, 0, 8);
+}
+
+.mood-card-disabled {
+    -fx-background-color: rgba(255, 255, 255, 0.70);
+    -fx-border-color: rgba(31, 41, 51, 0.06);
+    -fx-cursor: default;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.06), 16, 0.14, 0, 6);
+    -fx-opacity: 0.80;
+}
+
+/* Hover: stronger lift + subtle tint (kept ONCE) */
+.mood-card:hover {
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.20), 34, 0.22, 0, 14);
+    -fx-border-color: rgba(47, 111, 109, 0.32);
+    -fx-background-color: rgba(230, 242, 241, 0.35);
+}
+
+.mood-card:pressed {
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.14), 22, 0.18, 0, 8);
+    -fx-background-color: rgba(230, 242, 241, 0.22);
+}
+
+.mood-card-disabled:hover {
+    -fx-opacity: 0.65;
+}
+
+/* Icon scaling on hover  */
+.mood-card #mood_log {
+    -fx-image: url("../assets/icons/mood_log.png");
+    -fx-scale-x: 1;
+    -fx-scale-y: 1;
+    transition:
+            -fx-scale-x 0.5s ease,
+            -fx-scale-y 0.5s ease;
+}
+
+.mood-card:hover #mood_log {
+    -fx-scale-x: 1.5;
+    -fx-scale-y: 1.5;
+}
+
+.mood-card #mood_history {
+    -fx-image: url("../assets/icons/mood_history.png");
+    -fx-scale-x: 1;
+    -fx-scale-y: 1;
+    transition:
+            -fx-scale-x 0.5s ease,
+            -fx-scale-y 0.5s ease;
+}
+
+.mood-card:hover #mood_history {
+    -fx-scale-x: 1.5;
+    -fx-scale-y: 1.5;
+}
+
+.mood-card #mood_journal {
+    -fx-image: url("../assets/icons/mood_journal.png");
+    -fx-scale-x: 1;
+    -fx-scale-y: 1;
+    transition:
+            -fx-scale-x 0.5s ease,
+            -fx-scale-y 0.5s ease;
+}
+
+.mood-card:hover #mood_journal {
+    -fx-scale-x: 1.5;
+    -fx-scale-y: 1.5;
+}
+
+.mood-card-title {
+    -fx-font-size: 16px;
+    -fx-font-weight: 900;
+    -fx-text-fill: -ser-text;
+}
+
+.mood-card-sub {
+    -fx-font-size: 12px;
+    -fx-font-weight: 600;
+    -fx-text-fill: -ser-text2;
+    -fx-wrap-text: true;
+    -fx-alignment: center;
+    -fx-max-width: 420;
+}

--- a/project/mood-control/src/main/resources/styles/mood.css
+++ b/project/mood-control/src/main/resources/styles/mood.css
@@ -1,0 +1,385 @@
+/* =========================
+   Buttons (shared)
+   ========================= */
+.btn-primary {
+    -fx-background-color: -ser-primary;
+    -fx-text-fill: white;
+    -fx-font-weight: 800;
+    -fx-font-size: 12px;
+    -fx-padding: 8 14;
+    -fx-background-radius: 10;
+    -fx-cursor: hand;
+}
+
+.btn-primary:hover {
+    -fx-background-color: derive(-ser-primary, 6%);
+}
+
+.btn-ghost,
+.btn-ghost-danger {
+    -fx-padding: 8 14;
+    -fx-background-radius: 10;
+    -fx-border-radius: 10;
+    -fx-border-width: 1;
+    -fx-cursor: hand;
+}
+
+.btn-ghost {
+    -fx-background-color: #EFF4F4;
+    -fx-text-fill: -ser-text;
+    -fx-font-weight: 700;
+    -fx-font-size: 12px;
+    -fx-border-color: rgba(31, 41, 51, 0.10);
+}
+
+.btn-ghost:hover {
+    -fx-background-color: #E8EFEF;
+}
+
+.btn-ghost:pressed {
+    -fx-background-color: #E1EBEB;
+}
+
+.btn-ghost-danger {
+    -fx-background-color: #F7EDED;
+    -fx-text-fill: #7A1E1B;
+    -fx-font-weight: 800;
+    -fx-font-size: 12px;
+    -fx-border-color: rgba(217, 83, 79, 0.35);
+}
+
+.btn-ghost-danger:hover {
+    -fx-background-color: #F2E2E2;
+}
+
+.btn-ghost-danger:pressed {
+    -fx-background-color: #EED8D8;
+}
+
+/* =========================
+   WIZARD (State of Mind)
+   ========================= */
+.wizard-root {
+    -fx-background-color: transparent;
+}
+
+.wizard-wrap {
+    -fx-background-color: transparent;
+}
+
+/* Top row */
+.wizard-title {
+    -fx-text-fill: -ser-text;
+    -fx-font-size: 15px;
+    -fx-font-weight: 900;
+}
+
+/* merged wizard-counter*/
+.wizard-counter {
+    -fx-text-fill: -ser-primary;
+    -fx-font-size: 12px;
+    -fx-font-weight: 800;
+
+    -fx-background-color: rgba(47, 111, 109, 0.12);
+    -fx-background-radius: 14;
+    -fx-padding: 6 14;
+}
+
+/* Card host */
+.wizard-cardhost {
+    -fx-background-color: transparent;
+}
+
+.wizard-card {
+    -fx-background-color: rgba(230, 242, 241, 0.65);
+    -fx-background-radius: 18;
+    -fx-border-radius: 18;
+
+    -fx-border-color: rgba(47, 111, 109, 0.18);
+    -fx-border-width: 1.2;
+
+    -fx-padding: 26;
+
+    -fx-effect: dropshadow(gaussian,
+    rgba(47, 111, 109, 0.22),
+    22,
+    0.25,
+    0,
+    10);
+
+    -fx-min-height: 360;
+}
+
+/* Card text */
+.wizard-question {
+    -fx-text-fill: -ser-text;
+    -fx-font-size: 24px;
+    -fx-font-weight: 900;
+}
+
+.wizard-sub {
+    -fx-text-fill: -ser-text2;
+    -fx-font-size: 14px;
+    -fx-font-weight: 600;
+}
+
+/* Toggle buttons */
+.pick-btn {
+    -fx-background-color: linear-gradient(to bottom,
+    #F5FAFA,
+    #EFF4F4);
+
+    -fx-text-fill: -ser-text;
+    -fx-font-weight: 900;
+    -fx-font-size: 14px;
+
+    -fx-padding: 16 26;
+
+    -fx-background-radius: 18;
+    -fx-border-radius: 18;
+
+    -fx-border-color: rgba(31, 41, 51, 0.12);
+    -fx-border-width: 1;
+
+    -fx-cursor: hand;
+}
+
+.pick-btn:hover {
+    -fx-background-color: linear-gradient(to bottom,
+    #EAF3F3,
+    #E2EEEE);
+}
+
+.pick-btn:selected {
+    -fx-background-color: linear-gradient(to bottom,
+    rgba(47, 111, 109, 0.22),
+    rgba(47, 111, 109, 0.16));
+
+    -fx-border-color: -ser-primary;
+    -fx-border-width: 1.5;
+
+    -fx-text-fill: -ser-primary;
+
+    -fx-effect: dropshadow(gaussian,
+    rgba(47, 111, 109, 0.35),
+    14,
+    0.3,
+    0,
+    6);
+}
+
+/* =========================
+   Step 2: Mood
+   ========================= */
+.mood-circle-wrap {
+    -fx-min-height: 200;
+    -fx-alignment: center;
+}
+
+.mood-label {
+    -fx-text-fill: -ser-text;
+    -fx-font-size: 16px;
+    -fx-font-weight: 900;
+}
+
+/* Slider */
+.mood-slider .track {
+    -fx-background-color: rgba(31, 41, 51, 0.12);
+    -fx-background-radius: 999;
+    -fx-padding: 3;
+}
+
+.mood-slider .thumb {
+    -fx-background-color: -ser-primary;
+    -fx-background-radius: 999;
+    -fx-padding: 10;
+}
+
+.mood-slider:focused .thumb {
+    -fx-effect: dropshadow(gaussian, rgba(47, 111, 109, 0.35), 14, 0.25, 0, 4);
+}
+
+/* =========================
+   Step 3/4: Chips
+   ========================= */
+.chip-scroll {
+    -fx-background-color: transparent;
+    -fx-background: transparent;
+    -fx-border-color: transparent;
+}
+
+.chip-scroll > .viewport {
+    -fx-background-color: transparent;
+}
+
+.chip-pane {
+    -fx-background-color: transparent;
+}
+
+.chip-toggle {
+    -fx-background-color: rgba(255, 255, 255, 0.70);
+    -fx-text-fill: -ser-text;
+    -fx-font-size: 12px;
+    -fx-font-weight: 700;
+
+    -fx-padding: 8 12;
+    -fx-background-radius: 999;
+    -fx-border-radius: 999;
+    -fx-border-width: 1;
+    -fx-border-color: rgba(31, 41, 51, 0.12);
+
+    -fx-cursor: hand;
+}
+
+.chip-toggle:hover {
+    -fx-background-color: rgba(255, 255, 255, 0.92);
+}
+
+.chip-toggle:selected {
+    -fx-background-color: rgba(47, 111, 109, 0.18);
+    -fx-border-color: rgba(47, 111, 109, 0.45);
+    -fx-text-fill: -ser-text;
+}
+
+.chip-toggle:disabled {
+    -fx-opacity: 0.45;
+}
+
+/* =========================
+   MOOD HISTORY (Timeline)
+   ========================= */
+.history-top {}
+
+.history-filters {
+    -fx-padding: 10 12;
+    -fx-background-color: rgba(230, 242, 241, 0.55);
+    -fx-background-radius: 14;
+    -fx-border-radius: 14;
+    -fx-border-color: rgba(31, 41, 51, 0.08);
+    -fx-border-width: 1;
+}
+
+.filter-label {
+    -fx-text-fill: -ser-text2;
+    -fx-font-weight: 700;
+    -fx-font-size: 12px;
+}
+
+.filter-box {
+    -fx-background-radius: 12;
+    -fx-border-radius: 12;
+}
+
+.history-scroll {
+    -fx-background-color: transparent;
+}
+
+.history-scroll .viewport {
+    -fx-background-color: transparent;
+}
+
+.history-timeline {}
+
+.history-date {
+    -fx-text-fill: -ser-text;
+    -fx-font-weight: 900;
+    -fx-font-size: 13px;
+    -fx-padding: 8 2 2 2;
+}
+
+.history-card {
+    -fx-background-color: white;
+    -fx-background-radius: 16;
+    -fx-border-radius: 16;
+    -fx-border-color: rgba(31, 41, 51, 0.10);
+    -fx-border-width: 1;
+    -fx-padding: 14 14;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.08), 18, 0.18, 0, 6);
+    -fx-cursor: hand;
+}
+
+.history-card:hover {
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.16), 28, 0.22, 0, 12);
+    -fx-border-color: rgba(47, 111, 109, 0.22);
+}
+
+.history-card-title {
+    -fx-text-fill: -ser-text;
+    -fx-font-weight: 900;
+    -fx-font-size: 13px;
+}
+
+.history-card-sub {
+    -fx-text-fill: -ser-text2;
+    -fx-font-weight: 700;
+    -fx-font-size: 12px;
+}
+
+.history-chevron {
+    -fx-text-fill: -ser-text2;
+    -fx-font-size: 14px;
+    -fx-font-weight: 900;
+}
+
+.history-tags {}
+
+.history-details {
+    -fx-padding: 10 0 0 0;
+    -fx-border-color: rgba(31, 41, 51, 0.10);
+    -fx-border-width: 1 0 0 0;
+}
+
+.history-details-title {
+    -fx-text-fill: -ser-text;
+    -fx-font-weight: 900;
+    -fx-font-size: 12px;
+}
+
+/* Tags */
+.tag {
+    -fx-padding: 6 10;
+    -fx-background-radius: 999;
+    -fx-font-weight: 800;
+    -fx-font-size: 11px;
+}
+
+.emotion-tag {
+    -fx-background-color: rgba(47, 111, 109, 0.14);
+    -fx-text-fill: -ser-text;
+}
+
+.influence-tag {
+    -fx-background-color: rgba(136, 189, 188, 0.20);
+    -fx-text-fill: -ser-text;
+}
+
+.tag-more {
+    -fx-background-color: rgba(31, 41, 51, 0.08);
+    -fx-text-fill: -ser-text2;
+}
+
+/* Icon buttons (ONE OWNER = mood.css) */
+.icon-btn {
+    -fx-background-color: rgba(31, 41, 51, 0.06);
+    -fx-text-fill: -ser-text;
+    -fx-font-weight: 900;
+    -fx-background-radius: 10;
+    -fx-padding: 6 10;
+    -fx-cursor: hand;
+    -fx-font-size: 16px;
+}
+
+.icon-btn:hover {
+    -fx-background-color: rgba(31, 41, 51, 0.10);
+}
+
+.icon-btn-edit { }
+
+.icon-btn-delete {
+    -fx-background-color: rgba(217, 83, 79, 0.12);
+    -fx-text-fill: #7A1E1B;
+}
+
+.icon-btn-delete:hover {
+    -fx-background-color: rgba(217, 83, 79, 0.18);
+}

--- a/project/mood-control/src/main/resources/styles/styles.css
+++ b/project/mood-control/src/main/resources/styles/styles.css
@@ -1,812 +1,144 @@
+
+@import "mood-home.css";
+@import "mood.css";
+@import "journal.css";
+
 /* =========================
-   SERINITY — Palette 1
+   SERINITY — Palette 1 (GLOBAL)
    ========================= */
-
 .root {
-  -fx-font-family: "Segoe UI", system-ui, Arial;
+    -fx-font-family: "Segoe UI", system-ui, Arial;
 
-  -ser-primary: #2F6F6D;
-  -ser-secondary: #E6F2F1;
-  -ser-accent: #88BDBC;
+    -ser-primary: #2F6F6D;
+    -ser-secondary: #E6F2F1;
+    -ser-accent: #88BDBC;
 
-  -ser-bg: #F9FAFB;
-  -ser-text: #1F2933;
-  -ser-text2: #5F6C7B;
+    -ser-bg: #F9FAFB;
+    -ser-text: #1F2933;
+    -ser-text2: #5F6C7B;
 
-  -ser-success: #4CAF50;
-  -ser-warning: #F4B400;
-  -ser-error: #D9534F;
+    -ser-success: #4CAF50;
+    -ser-warning: #F4B400;
+    -ser-error: #D9534F;
 }
 
 .app-bg {
-  -fx-background-color: -ser-bg;
+    -fx-background-color: -ser-bg;
 }
 
-/* =========================
-   TOP BAR
-   ========================= */
-
-.topbar {
-  -fx-background-color: linear-gradient(to bottom, derive(-ser-primary, 8%), -ser-primary);
-  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.18), 18, 0.15, 0, 6);
-}
-
-.brand-title {
-  -fx-text-fill: white;
-  -fx-font-size: 18px;
-  -fx-font-weight: 800;
-}
-
-/* =========================
-   NAV BUTTONS
-   ========================= */
-
-.nav-btn {
-  -fx-background-color: transparent;
-  -fx-text-fill: rgba(255, 255, 255, 0.88);
-  -fx-font-size: 13px;
-  -fx-font-weight: 700;
-  -fx-padding: 8 12;
-  -fx-background-radius: 12;
-  -fx-cursor: hand;
-}
-
-.nav-btn:hover {
-  -fx-background-color: rgba(255, 255, 255, 0.14);
-  -fx-text-fill: white;
-}
-
-.nav-btn:pressed {
-  -fx-background-color: rgba(255, 255, 255, 0.20);
-}
-
-.nav-btn-active {
-  -fx-background-color: rgba(255, 255, 255, 0.22);
-  -fx-text-fill: white;
-}
-
-/* =========================
-   SEARCH BOX
-   ========================= */
-
-.search {
-  -fx-background-color: rgba(255, 255, 255, 0.18);
-  -fx-background-radius: 12;
-  -fx-padding: 6 10;
-  -fx-alignment: center-left;
-}
-
-.search-icon {
-  -fx-text-fill: rgba(255, 255, 255, 0.92);
-}
-
-.search-field {
-  -fx-background-color: transparent;
-  -fx-text-fill: white;
-  -fx-prompt-text-fill: rgba(255, 255, 255, 0.70);
-  -fx-border-color: transparent;
-}
-
-.user-name {
-  -fx-text-fill: rgba(255, 255, 255, 0.92);
-  -fx-font-size: 13px;
-  -fx-font-weight: 600;
-}
-
-.avatar {
-  -fx-background-radius: 999;
-  -fx-border-radius: 999;
-  -fx-border-color: rgba(255, 255, 255, 0.35);
-  -fx-border-width: 1;
-}
-
-/* =========================
-   PAGE HEADER (used in MoodHome)
-   ========================= */
-
-.page-title {
-  -fx-text-fill: -ser-text;
-  -fx-font-size: 16px;
-  -fx-font-weight: 800;
-}
-
-.page-hint {
-  -fx-background-color: rgba(47, 111, 109, 0.20);
-  -fx-background-radius: 16;
-  -fx-padding: 10 22;
-  -fx-font-size: 14px;
-  -fx-font-weight: 900;
-  -fx-text-fill: #1F2933;
-}
-
-/* =========================
-   CONTENT HOST
-   ========================= */
-
-.content-host {
-  -fx-background-color: transparent;
-}
-
-.blank-page {
-  -fx-background-color: transparent;
-}
-
-
-/* =========================
-   MOOD HOME (Hub cards)
-   ========================= */
-
-/* Row container */
-.mood-hub-row {
-  -fx-background-color: transparent;
-}
-
-.mood-host {
-  -fx-background-color: transparent;
-}
-
-/* Grid container (optional, just ensures it doesn't look cramped) */
-.mood-card-grid {
-  -fx-background-color: transparent;
-}
-
-/* Base card */
-.mood-card {
-  -fx-alignment: center;
-  -fx-background-color: rgba(255, 255, 255, 0.92);
-  -fx-background-radius: 18;
-  -fx-border-radius: 18;
-  -fx-border-color: rgba(31, 41, 51, 0.08);
-  -fx-border-width: 1;
-
-  -fx-padding: 22;
-  -fx-cursor: hand;
-
-  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.10), 20, 0.18, 0, 8);
-}
-
-/* Disabled card (Journal for now) */
-.mood-card-disabled {
-  -fx-background-color: rgba(255, 255, 255, 0.70);
-  -fx-border-color: rgba(31, 41, 51, 0.06);
-  -fx-cursor: default;
-  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.06), 16, 0.14, 0, 6);
-  -fx-opacity: 0.80;
-}
-
-/* Hover: stronger lift + subtle tint */
-.mood-card:hover {
-    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.20), 34, 0.22, 0, 14);
-    -fx-border-color: rgba(47, 111, 109, 0.32);
-    -fx-background-color: rgba(230, 242, 241, 0.35);
-    /* very light ser-secondary tint */
-}
-
-.mood-card #mood_log {
-    -fx-image: url("../assets/icons/mood_log.png");
-    -fx-scale-x: 1;
-    -fx-scale-y: 1;
-    transition:
-            -fx-scale-x 0.5s ease,
-            -fx-scale-y 0.5s ease;
-}
-
-.mood-card:hover #mood_log {
-    -fx-scale-x: 1.5;
-    -fx-scale-y: 1.5;
-}
-.mood-card #mood_history {
-    -fx-image: url("../assets/icons/mood_history.png");
-    -fx-scale-x: 1;
-    -fx-scale-y: 1;
-    transition:
-            -fx-scale-x 0.5s ease,
-            -fx-scale-y 0.5s ease;
-}
-
-.mood-card:hover #mood_history {
-    -fx-scale-x: 1.5;
-    -fx-scale-y: 1.5;
-}
-
-.mood-card #mood_journal {
-     -fx-image: url("../assets/icons/mood_journal.png");
-     -fx-scale-x: 1;
-     -fx-scale-y: 1;
-     transition:
-             -fx-scale-x 0.5s ease,
-             -fx-scale-y 0.5s ease;
- }
-
-.mood-card:hover #mood_journal {
-    -fx-scale-x: 1.5;
-    -fx-scale-y: 1.5;
-}
-
-
-.mood-card-title {
-  -fx-font-size: 16px;
-  -fx-font-weight: 900;
-  -fx-text-fill: -ser-text;
-}
-
-.mood-card-sub {
-  -fx-font-size: 12px;
-  -fx-font-weight: 600;
-  -fx-text-fill: -ser-text2;
-  -fx-wrap-text: true;
-  -fx-alignment: center;
-  -fx-max-width: 420;
-}
-
-/* Hover: stronger lift + subtle tint */
-.mood-card:hover {
-  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.20), 34, 0.22, 0, 14);
-  -fx-border-color: rgba(47, 111, 109, 0.32);
-  -fx-background-color: rgba(230, 242, 241, 0.35);
-  /* very light ser-secondary tint */
-}
-
-/* Press feedback */
-.mood-card:pressed {
-  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.14), 22, 0.18, 0, 8);
-  -fx-background-color: rgba(230, 242, 241, 0.22);
-}
-
-/* Don't hover-highlight disabled card */
-.mood-card-disabled:hover {
-  -fx-opacity: 0.65;
-
-}
-
-
-/* =========================
-   Buttons (keep for later)
-   ========================= */
-
-.btn-primary {
-  -fx-background-color: -ser-primary;
-  -fx-text-fill: white;
-  -fx-font-weight: 800;
-  -fx-font-size: 12px;
-  -fx-padding: 8 14;
-  -fx-background-radius: 10;
-  -fx-cursor: hand;
-}
-
-.btn-primary:hover {
-  -fx-background-color: derive(-ser-primary, 6%);
-}
-
-.btn-ghost,
-.btn-ghost-danger {
-  -fx-padding: 8 14;
-  -fx-background-radius: 10;
-  -fx-border-radius: 10;
-  -fx-border-width: 1;
-  -fx-cursor: hand;
-}
-
-.btn-ghost {
-  -fx-background-color: #EFF4F4;
-  -fx-text-fill: -ser-text;
-  -fx-font-weight: 700;
-  -fx-font-size: 12px;
-  -fx-border-color: rgba(31, 41, 51, 0.10);
-}
-
-.btn-ghost:hover {
-  -fx-background-color: #E8EFEF;
-}
-
-.btn-ghost:pressed {
-  -fx-background-color: #E1EBEB;
-}
-
-.btn-ghost-danger {
-  -fx-background-color: #F7EDED;
-  -fx-text-fill: #7A1E1B;
-  -fx-font-weight: 800;
-  -fx-font-size: 12px;
-  -fx-border-color: rgba(217, 83, 79, 0.35);
-}
-
-.btn-ghost-danger:hover {
-  -fx-background-color: #F2E2E2;
-}
-
-.btn-ghost-danger:pressed {
-  -fx-background-color: #EED8D8;
-}
-
-/* =========================
-   WIZARD (State of Mind)
-   ========================= */
-
-.wizard-root {
-  -fx-background-color: transparent;
-}
-
-.wizard-wrap {
-  -fx-background-color: transparent;
-}
-
-/* Top row */
-.wizard-title {
-  -fx-text-fill: -ser-text;
-  -fx-font-size: 15px;
-  -fx-font-weight: 900;
-}
-
-.wizard-counter {
-  -fx-text-fill: -ser-text2;
-  -fx-font-size: 12px;
-  -fx-font-weight: 700;
-}
-
-/* Card host */
-.wizard-cardhost {
-  -fx-background-color: transparent;
-}
-
-.wizard-card {
-  -fx-background-color: rgba(230, 242, 241, 0.65);
-  -fx-background-radius: 18;
-  -fx-border-radius: 18;
-
-  -fx-border-color: rgba(47, 111, 109, 0.18);
-  -fx-border-width: 1.2;
-
-  -fx-padding: 26;
-
-  -fx-effect: dropshadow(gaussian,
-      rgba(47, 111, 109, 0.22),
-      22,
-      0.25,
-      0,
-      10);
-
-  -fx-min-height: 360;
-}
-
-
-/* Card text */
-.wizard-question {
-  -fx-text-fill: -ser-text;
-  -fx-font-size: 24px;
-  -fx-font-weight: 900;
-}
-
-
-.wizard-sub {
-  -fx-text-fill: -ser-text2;
-  -fx-font-size: 14px;
-  -fx-font-weight: 600;
-}
-
-/* Toggle buttons that look like normal premium buttons */
-.pick-btn {
-  -fx-background-color: linear-gradient(to bottom,
-      #F5FAFA,
-      #EFF4F4);
-
-  -fx-text-fill: -ser-text;
-  -fx-font-weight: 900;
-  -fx-font-size: 14px;
-
-  -fx-padding: 16 26;
-
-  -fx-background-radius: 18;
-  -fx-border-radius: 18;
-
-  -fx-border-color: rgba(31, 41, 51, 0.12);
-  -fx-border-width: 1;
-
-  -fx-cursor: hand;
-}
-
-.pick-btn:hover {
-  -fx-background-color: linear-gradient(to bottom,
-      #EAF3F3,
-      #E2EEEE);
-}
-
-
-.pick-btn:selected {
-  -fx-background-color: linear-gradient(to bottom,
-      rgba(47, 111, 109, 0.22),
-      rgba(47, 111, 109, 0.16));
-
-  -fx-border-color: -ser-primary;
-  -fx-border-width: 1.5;
-
-  -fx-text-fill: -ser-primary;
-
-  -fx-effect: dropshadow(gaussian,
-      rgba(47, 111, 109, 0.35),
-      14,
-      0.3,
-      0,
-      6);
-}
-
-.wizard-counter {
-  -fx-background-color: rgba(47, 111, 109, 0.12);
-  -fx-background-radius: 14;
-  -fx-padding: 6 14;
-
-  -fx-text-fill: -ser-primary;
-  -fx-font-size: 12px;
-  -fx-font-weight: 800;
-}
-
-/* =========================
-   Step 2: Mood
-   ========================= */
-
-.mood-circle-wrap {
-  -fx-min-height: 200;
-  -fx-alignment: center;
-}
-
-.mood-label {
-  -fx-text-fill: -ser-text;
-  -fx-font-size: 16px;
-  -fx-font-weight: 900;
-}
-
-/* Slider styling */
-
-.mood-slider .track {
-  -fx-background-color: rgba(31, 41, 51, 0.12);
-  -fx-background-radius: 999;
-  -fx-padding: 3;
-  /* thickness */
-}
-
-.mood-slider .thumb {
-  -fx-background-color: -ser-primary;
-  -fx-background-radius: 999;
-  -fx-padding: 10;
-}
-
-
-.mood-slider:focused .thumb {
-  -fx-effect: dropshadow(gaussian, rgba(47, 111, 109, 0.35), 14, 0.25, 0, 4);
-}
-
-/* =========================
-   Step 3: Emotions - toggle chips
-   ========================= */
-
-.chip-scroll {
-  -fx-background-color: transparent;
-  -fx-background: transparent;
-  -fx-border-color: transparent;
-}
-
-.chip-scroll>.viewport {
-  -fx-background-color: transparent;
-}
-
-.chip-pane {
-  -fx-background-color: transparent;
-}
-
-/* ToggleButton styled like a pill button */
-.chip-toggle {
-  -fx-background-color: rgba(255, 255, 255, 0.70);
-  -fx-text-fill: -ser-text;
-  -fx-font-size: 12px;
-  -fx-font-weight: 700;
-
-  -fx-padding: 8 12;
-  -fx-background-radius: 999;
-  -fx-border-radius: 999;
-  -fx-border-width: 1;
-  -fx-border-color: rgba(31, 41, 51, 0.12);
-
-  -fx-cursor: hand;
-}
-
-.chip-toggle:hover {
-  -fx-background-color: rgba(255, 255, 255, 0.92);
-}
-
-.chip-toggle:selected {
-  -fx-background-color: rgba(47, 111, 109, 0.18);
-  -fx-border-color: rgba(47, 111, 109, 0.45);
-  -fx-text-fill: -ser-text;
-}
-
-.chip-toggle:disabled {
-  -fx-opacity: 0.45;
-}
-
-/* =========================
-   MOOD HISTORY (Timeline)
-   ========================= */
-
-.history-top {}
-
-.history-filters {
-  -fx-padding: 10 12;
-  -fx-background-color: rgba(230, 242, 241, 0.55);
-  -fx-background-radius: 14;
-  -fx-border-radius: 14;
-  -fx-border-color: rgba(31, 41, 51, 0.08);
-  -fx-border-width: 1;
-}
-
-.filter-label {
-  -fx-text-fill: -ser-text2;
-  -fx-font-weight: 700;
-  -fx-font-size: 12px;
-}
-
-.filter-box {
-  -fx-background-radius: 12;
-  -fx-border-radius: 12;
-}
-
-.history-scroll {
-  -fx-background-color: transparent;
-}
-
-.history-scroll .viewport {
-  -fx-background-color: transparent;
-}
-
-.history-timeline {}
-
-.history-date {
-  -fx-text-fill: -ser-text;
-  -fx-font-weight: 900;
-  -fx-font-size: 13px;
-  -fx-padding: 8 2 2 2;
-}
-
-.history-card {
-  -fx-background-color: white;
-  -fx-background-radius: 16;
-  -fx-border-radius: 16;
-  -fx-border-color: rgba(31, 41, 51, 0.10);
-  -fx-border-width: 1;
-  -fx-padding: 14 14;
-  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.08), 18, 0.18, 0, 6);
-  -fx-cursor: hand;
-}
-
-.history-card:hover {
-  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.16), 28, 0.22, 0, 12);
-  -fx-border-color: rgba(47, 111, 109, 0.22);
-}
-
-.history-card-title {
-  -fx-text-fill: -ser-text;
-  -fx-font-weight: 900;
-  -fx-font-size: 13px;
-}
-
-.history-card-sub {
-  -fx-text-fill: -ser-text2;
-  -fx-font-weight: 700;
-  -fx-font-size: 12px;
-}
-
-.history-chevron {
-  -fx-text-fill: -ser-text2;
-  -fx-font-size: 14px;
-  -fx-font-weight: 900;
-}
-
-.history-tags {}
-
-.history-details {
-  -fx-padding: 10 0 0 0;
-  -fx-border-color: rgba(31, 41, 51, 0.10);
-  -fx-border-width: 1 0 0 0;
-}
-
-.history-details-title {
-  -fx-text-fill: -ser-text;
-  -fx-font-weight: 900;
-  -fx-font-size: 12px;
-}
-
-/* Tags */
-.tag {
-  -fx-padding: 6 10;
-  -fx-background-radius: 999;
-  -fx-font-weight: 800;
-  -fx-font-size: 11px;
-}
-
-.emotion-tag {
-  -fx-background-color: rgba(47, 111, 109, 0.14);
-  -fx-text-fill: -ser-text;
-}
-
-.influence-tag {
-  -fx-background-color: rgba(136, 189, 188, 0.20);
-  -fx-text-fill: -ser-text;
-}
-
-.tag-more {
-  -fx-background-color: rgba(31, 41, 51, 0.08);
-  -fx-text-fill: -ser-text2;
-}
-
-.icon-btn {
-  -fx-background-color: rgba(31, 41, 51, 0.06);
-  -fx-text-fill: -ser-text;
-  -fx-font-weight: 900;
-  -fx-background-radius: 10;
-  -fx-padding: 6 10;
-  -fx-cursor: hand; -fx-font-size: 16px;
-}
-
-
-
-.icon-btn:hover {
-  -fx-background-color: rgba(31, 41, 51, 0.10);
-}
-
-.icon-btn-edit {
-  /* keeps default calm look */
-}
-
-.icon-btn-delete {
-  -fx-background-color: rgba(217, 83, 79, 0.12);
-  -fx-text-fill: #7A1E1B;
-}
-
-.icon-btn-delete:hover {
-  -fx-background-color: rgba(217, 83, 79, 0.18);
-}
-
-/* ===== Footer (Serinity style) ===== */
-
-.footer-bar {
-  -fx-padding: 10 20 10 20;
-
-  /* same Serinity navbar vibe */
-  -fx-background-color: linear-gradient(to right,
-      #2f6f6d,
-      #3b8f8b);
-
-  -fx-border-width: 1 0 0 0;
-  -fx-border-color: rgba(255, 255, 255, 0.15);
-}
-
-.footer-bar Label {
-  -fx-font-size: 12px;
-  -fx-font-weight: 800;
-  -fx-text-fill: rgba(255, 255, 255, 0.75);
-}
-
-
-/* ===== Journal editor polish ===== */
-
-.journal-card {
-    -fx-background-color: white;
-    -fx-background-radius: 14;
-    -fx-border-radius: 14;
-    -fx-padding: 14;
-    -fx-spacing: 6;
-    -fx-border-width: 0 0 0 4;
-    -fx-border-color: transparent transparent transparent rgba(47,127,122,0.35);
-    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.06), 18, 0.12, 0, 2);
-}
-.journal-card:hover {
-    -fx-background-color: #F4FBFA;
-    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.09), 22, 0.14, 0, 3);
-}
-.journal-card-title {
-    -fx-font-size: 15px;
-    -fx-font-weight: bold;
-    -fx-text-fill: #1F5E5A;
-}
-.journal-card-meta {
-    -fx-font-size: 12px;
-    -fx-text-fill: rgba(47,127,122,0.65);
-}
-.journal-card-preview {
-    -fx-font-size: 13.5px;
-    -fx-text-fill: rgba(0,0,0,0.78);
-    -fx-wrap-text: true;
-    -fx-font-style: italic;
-}
-.journal-card .icon-btn {
-    -fx-background-color: rgba(31, 41, 51, 0.06);
-    -fx-text-fill: rgba(0,0,0,0.45);
-}
-.journal-card .icon-btn-delete {
-    -fx-text-fill: #B12B28; /* muted red */
-    -fx-background-color: rgba(217, 83, 79, 0.10);
-
-}
-
-.journal-card .icon-btn:hover {
-    -fx-background-color: rgba(47,127,122,0.12);
-    -fx-text-fill: #2F7F7A;
-}
-.journal-card .icon-btn-delete:hover {
-    -fx-background-color: rgba(217, 83, 79, 0.22);
-    -fx-text-fill: #7A1E1B;
-}
-
-.editor-panel {
-    -fx-background-color: #F2FAF9; /* soft teal-tinted white */
-    -fx-background-radius: 18;
-    -fx-border-radius: 18;
-    -fx-border-color: rgba(47,127,122,0.18);
-    -fx-border-width: 1;
-    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.14), 26, 0.16, -7, 0);
-}
-
-/* Title hierarchy */
-.editor-title {
-    -fx-font-size: 18px;
-    -fx-font-weight: bold;
-    -fx-text-fill: #1F5E5A; /* dark teal */
-}
-
-
-.editor-subtitle {
-    -fx-font-size: 12.5px;
-    -fx-text-fill: rgba(31,94,90,0.65);
-}
-
-
-/* Prompt sections */
-.prompt-block {
-    -fx-padding: 12 0 6 12;
-    -fx-border-color: transparent transparent transparent rgba(47,127,122,0.35);
-    -fx-border-width: 0 0 0 3;
-}
-
-/* Questions feel like guidance (not a form label) */
-.prompt-q {
-    -fx-font-size: 13.5px;
-    -fx-font-weight: bold;
-    -fx-text-fill: #2F7F7A; /* primary teal */
-}
-
-
-.prompt-hint {
-    -fx-font-size: 12px;
-    -fx-text-fill: rgba(47,127,122,0.55);
-}
-
-/* focus */
-.prompt-answer {
-    -fx-background-radius: 14;
-    -fx-border-radius: 5;
-    -fx-padding: 5;
-    -fx-border-color: rgba(47,127,122,0.18);
-    -fx-background-color: #FFFFFF;
-}
-.prompt-answer:focused {
-    -fx-border-color: #2F7F7A;
-    -fx-effect: dropshadow(gaussian, rgba(47,127,122,0.25), 12, 0.3, 0, 0);
-}
-
-
-/* Softer focus ring */
+/* Global focus (moved from journal) */
 .text-area:focused, .text-field:focused {
     -fx-border-color: rgba(0,0,0,0.18);
     -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.08), 10, 0.2, 0, 0);
 }
 
-/* Dim overlay - calm */
-.overlay-dim {
-    -fx-background-color: rgba(31,94,90,0.25);
-}
-.save-hint {
-    -fx-font-size: 12px;
-    -fx-text-fill: rgba(31,94,90,0.65);
-    -fx-padding: 0 2 0 0;
-    -fx-alignment: CENTER_RIGHT;
+/* =========================
+   TOP BAR (Template.fxml)
+   ========================= */
+.topbar {
+    -fx-background-color: linear-gradient(
+            from 0% 0% to 0% 100%,
+            derive(-ser-primary, 8%),
+            -ser-primary
+    );
 }
 
+
+
+.brand-title {
+    -fx-text-fill: white;
+    -fx-font-size: 18px;
+    -fx-font-weight: 800;
+}
+
+/* =========================
+   NAV BUTTONS (Template.fxml)
+   ========================= */
+.nav-btn {
+    -fx-background-color: transparent;
+    -fx-text-fill: rgba(255, 255, 255, 0.88);
+    -fx-font-size: 13px;
+    -fx-font-weight: 700;
+    -fx-padding: 8 12;
+    -fx-background-radius: 12;
+    -fx-cursor: hand;
+}
+
+.nav-btn:hover {
+    -fx-background-color: rgba(255, 255, 255, 0.14);
+    -fx-text-fill: white;
+}
+
+.nav-btn:pressed {
+    -fx-background-color: rgba(255, 255, 255, 0.20);
+}
+
+.nav-btn-active {
+    -fx-background-color: rgba(255, 255, 255, 0.22);
+    -fx-text-fill: white;
+}
+
+/* =========================
+   SEARCH BOX (Template.fxml)
+   ========================= */
+.search {
+    -fx-background-color: rgba(255, 255, 255, 0.18);
+    -fx-background-radius: 12;
+    -fx-padding: 6 10;
+    -fx-alignment: center-left;
+}
+
+.search-icon {
+    -fx-text-fill: rgba(255, 255, 255, 0.92);
+}
+
+.search-field {
+    -fx-background-color: transparent;
+    -fx-text-fill: white;
+    -fx-prompt-text-fill: rgba(255, 255, 255, 0.70);
+    -fx-border-color: transparent;
+}
+
+.user-name {
+    -fx-text-fill: rgba(255, 255, 255, 0.92);
+    -fx-font-size: 13px;
+    -fx-font-weight: 600;
+}
+
+.avatar {
+    -fx-background-radius: 999;
+    -fx-border-radius: 999;
+    -fx-border-color: rgba(255, 255, 255, 0.35);
+    -fx-border-width: 1;
+}
+
+/* =========================
+   CONTENT HOST (Template.fxml)
+   ========================= */
+.content-host {
+    -fx-background-color: transparent;
+}
+
+.blank-page {
+    -fx-background-color: transparent;
+}
+
+/* =========================
+   Footer (Template.fxml)
+   ========================= */
+.footer-bar {
+    -fx-padding: 10 20 10 20;
+
+    -fx-background-color: linear-gradient(to right,
+    #2f6f6d,
+    #3b8f8b);
+
+    -fx-border-width: 1 0 0 0;
+    -fx-border-color: rgba(255, 255, 255, 0.15);
+}
+
+.footer-bar Label {
+    -fx-font-size: 12px;
+    -fx-font-weight: 800;
+    -fx-text-fill: rgba(255, 255, 255, 0.75);
+}


### PR DESCRIPTION
This PR splits the big styles.css file into smaller files based on app screens.

Changes

- Keep common styles in styles.css

Add:

- mood-home.css for Mood home

- mood.css for Mood wizard and history

- journal.css for Journal screens

